### PR TITLE
Sprint 2: increment 5

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bq2cd/yp-go-metrics/internal/agent"
 	"github.com/bq2cd/yp-go-metrics/internal/agent/source"
+	"github.com/bq2cd/yp-go-metrics/internal/app/envparser"
 	config "github.com/bq2cd/yp-go-metrics/internal/config/agent"
 	"github.com/bq2cd/yp-go-metrics/internal/repository"
 	"github.com/go-resty/resty/v2"
@@ -22,6 +23,12 @@ const (
 	defaultPollIntervalSec   = 2
 	defaultReportIntervalSec = 10
 )
+
+type cliOptions struct {
+	UpstreamURL    string `env:"ADDRESS"`
+	PollInterval   uint   `env:"POLL_INTERVAL"`
+	ReportInterval uint   `env:"REPORT_INTERVAL"`
+}
 
 func runAgent(ctx context.Context, cfg config.Config) error {
 	log.Printf("sending metrics to %s every %v (poll interval %v)", cfg.UpstreamURL.String(), cfg.ReportInterval, cfg.PollInterval)
@@ -36,25 +43,27 @@ func runAgent(ctx context.Context, cfg config.Config) error {
 	return ag.Run()
 }
 
-func parseArgs(fs *flag.FlagSet, args []string) (config.Config, error) {
-	var (
-		upstreamURL    string
-		pollInterval   uint
-		reportInterval uint
-	)
+func parseArgs(fs *flag.FlagSet, args []string, envParser envparser.Parser) (config.Config, error) {
+	var opts cliOptions
 
-	fs.StringVar(&upstreamURL, "a", defaultUpstreamURL, "upstream url in the format [http://]HOST[:PORT]")
-	fs.UintVar(&pollInterval, "p", defaultPollIntervalSec, "poll interval in seconds")
-	fs.UintVar(&reportInterval, "r", defaultReportIntervalSec, "report interval in seconds")
+	fs.StringVar(&opts.UpstreamURL, "a", defaultUpstreamURL, "upstream url in the format [http://]HOST[:PORT]")
+	fs.UintVar(&opts.PollInterval, "p", defaultPollIntervalSec, "poll interval in seconds")
+	fs.UintVar(&opts.ReportInterval, "r", defaultReportIntervalSec, "report interval in seconds")
 
+	// parse flags
 	if err := fs.Parse(args); err != nil {
 		return config.Config{}, fmt.Errorf("invalid args: %w", err)
 	}
 
+	// parse env vars (take precedence over flags)
+	if err := envParser.Parse(&opts); err != nil {
+		return config.Config{}, fmt.Errorf("invalid env vars: %w", err)
+	}
+
 	cfg, err := config.New(
-		config.UpstreamURL(upstreamURL),
-		config.PollInterval(pollInterval),
-		config.ReportInterval(reportInterval),
+		config.UpstreamURL(opts.UpstreamURL),
+		config.PollInterval(opts.PollInterval),
+		config.ReportInterval(opts.ReportInterval),
 	)
 	if err != nil {
 		return config.Config{}, fmt.Errorf("unable to construct config: %w", err)
@@ -71,7 +80,7 @@ func run(ctx context.Context, args []string, stderr io.Writer) error {
 	fs := flag.NewFlagSet("agent", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
-	cfg, err := parseArgs(fs, args)
+	cfg, err := parseArgs(fs, args, envparser.NewParser())
 	if err != nil {
 		return fmt.Errorf("unable to parse args: %w", err)
 	}

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -12,7 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bq2cd/yp-go-metrics/internal/app/envparser"
 	config "github.com/bq2cd/yp-go-metrics/internal/config/agent"
+	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -30,7 +32,7 @@ func Test_parseArgs(t *testing.T) {
 		{
 			name: "no args",
 			args: args{args: []string{}},
-			want: config.Config{UpstreamURL: url.URL{Scheme: "http", Host: "localhost:8080"}, PollInterval: defaultPollIntervalSec * time.Second, ReportInterval: defaultReportIntervalSec * time.Second},
+			want: config.Config{UpstreamURL: url.URL{Scheme: "http", Host: defaultUpstreamURL}, PollInterval: defaultPollIntervalSec * time.Second, ReportInterval: defaultReportIntervalSec * time.Second},
 			assertion: func(t assert.TestingT, err error, v ...any) bool {
 				return assert.NoError(t, err)
 			},
@@ -144,7 +146,85 @@ func Test_parseArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
 			fs.SetOutput(io.Discard)
-			got, err := parseArgs(fs, tt.args.args)
+			got, err := parseArgs(fs, tt.args.args, envparser.NewParserWithOptions(env.Options{Environment: map[string]string{}}))
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseArgs_withEnv(t *testing.T) {
+	type args struct {
+		args []string
+		env  map[string]string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      config.Config
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "env overrides address",
+			args: args{
+				args: []string{"-a=localhost:9090", "-r=20", "-p=5"},
+				env:  map[string]string{"ADDRESS": "localhost:3333"},
+			},
+			want: config.Config{UpstreamURL: url.URL{Scheme: "http", Host: "localhost:3333"}, PollInterval: 5 * time.Second, ReportInterval: 20 * time.Second},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "env overrides poll interval",
+			args: args{
+				args: []string{"-a=localhost:9090", "-r=20", "-p=5"},
+				env:  map[string]string{"POLL_INTERVAL": "19"},
+			},
+			want: config.Config{UpstreamURL: url.URL{Scheme: "http", Host: "localhost:9090"}, PollInterval: 19 * time.Second, ReportInterval: 20 * time.Second},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "env overrides report interval",
+			args: args{
+				args: []string{"-a=localhost:9090", "-r=20", "-p=5"},
+				env:  map[string]string{"REPORT_INTERVAL": "81"},
+			},
+			want: config.Config{UpstreamURL: url.URL{Scheme: "http", Host: "localhost:9090"}, PollInterval: 5 * time.Second, ReportInterval: 81 * time.Second},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "env invalid report interval",
+			args: args{
+				args: []string{"-a=localhost:9090", "-r=20", "-p=5"},
+				env:  map[string]string{"REPORT_INTERVAL": "-30"},
+			},
+			want: config.Config{},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.Error(t, err)
+			},
+		},
+		{
+			name: "env invalid poll interval",
+			args: args{
+				args: []string{"-a=localhost:9090", "-r=20", "-p=5"},
+				env:  map[string]string{"POLL_INTERVAL": "not a number"},
+			},
+			want: config.Config{},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.Error(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			got, err := parseArgs(fs, tt.args.args, envparser.NewParserWithOptions(env.Options{Environment: tt.args.env}))
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/bq2cd/yp-go-metrics/internal/app/envparser"
 	config "github.com/bq2cd/yp-go-metrics/internal/config/server"
 	"github.com/bq2cd/yp-go-metrics/internal/handler"
 	"github.com/bq2cd/yp-go-metrics/internal/repository"
@@ -22,6 +23,11 @@ const (
 	defaultShutdownTimeoutSec = 1
 )
 
+type cliOptions struct {
+	ListenAddress   string `env:"ADDRESS"`
+	ShutdownTimeout uint   `env:"SHUTDOWN_TIMEOUT"`
+}
+
 func runServer(ctx context.Context, cfg config.Config) error {
 	storage := repository.NewMemStorage()
 	svc := service.NewMetrics(storage)
@@ -32,22 +38,23 @@ func runServer(ctx context.Context, cfg config.Config) error {
 	return srv.Run()
 }
 
-func parseArgs(fs *flag.FlagSet, args []string) (config.Config, error) {
-	var (
-		listenAddress   string
-		shutdownTimeout uint
-	)
+func parseArgs(fs *flag.FlagSet, args []string, envParser envparser.Parser) (config.Config, error) {
+	var opts cliOptions
 
-	fs.StringVar(&listenAddress, "a", defaultAddress, "listen address in the format [HOST]:PORT")
-	fs.UintVar(&shutdownTimeout, "t", defaultShutdownTimeoutSec, "graceful shutdown timeout in seconds")
+	fs.StringVar(&opts.ListenAddress, "a", defaultAddress, "listen address in the format [HOST]:PORT")
+	fs.UintVar(&opts.ShutdownTimeout, "t", defaultShutdownTimeoutSec, "graceful shutdown timeout in seconds")
 
 	if err := fs.Parse(args); err != nil {
 		return config.Config{}, fmt.Errorf("invalid args: %w", err)
 	}
 
+	if err := envParser.Parse(&opts); err != nil {
+		return config.Config{}, fmt.Errorf("invalid env vars: %w", err)
+	}
+
 	cfg, err := config.New(
-		config.ListenAddress(listenAddress),
-		config.ShutdownTimeout(shutdownTimeout),
+		config.ListenAddress(opts.ListenAddress),
+		config.ShutdownTimeout(opts.ShutdownTimeout),
 	)
 	if err != nil {
 		return config.Config{}, fmt.Errorf("unable to construct config: %w", err)
@@ -64,7 +71,7 @@ func run(ctx context.Context, args []string, stderr io.Writer) error {
 	fs := flag.NewFlagSet("server", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
-	cfg, err := parseArgs(fs, args)
+	cfg, err := parseArgs(fs, args, envparser.NewParser())
 	if err != nil {
 		return fmt.Errorf("failed to parse args: %w", err)
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bq2cd/yp-go-metrics/internal/app/envparser"
 	config "github.com/bq2cd/yp-go-metrics/internal/config/server"
 	"github.com/bq2cd/yp-go-metrics/internal/server/servertest"
+	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,7 +121,85 @@ func Test_parseArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
 			fs.SetOutput(io.Discard)
-			got, err := parseArgs(fs, tt.args.args)
+			got, err := parseArgs(fs, tt.args.args, envparser.NewParserWithOptions(env.Options{Environment: map[string]string{}}))
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseArgs_withEnv(t *testing.T) {
+	type args struct {
+		args []string
+		env  map[string]string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      config.Config
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "env overrides address",
+			args: args{
+				args: []string{"-a=localhost:9090"},
+				env:  map[string]string{"ADDRESS": "localhost:3333"},
+			},
+			want: config.Config{ListenAddress: "localhost:3333", ShutdownTimeout: defaultShutdownTimeoutSec * time.Second},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "env overrides shutdown timeout",
+			args: args{
+				args: []string{"-a=localhost:9090"},
+				env:  map[string]string{"SHUTDOWN_TIMEOUT": "21"},
+			},
+			want: config.Config{ListenAddress: "localhost:9090", ShutdownTimeout: 21 * time.Second},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "env overrides shutdown timeout 2",
+			args: args{
+				args: []string{"-a=localhost:9090", "-t=13"},
+				env:  map[string]string{"SHUTDOWN_TIMEOUT": "21"},
+			},
+			want: config.Config{ListenAddress: "localhost:9090", ShutdownTimeout: 21 * time.Second},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "env invalid shutdown timeout",
+			args: args{
+				args: []string{"-a=localhost:9090"},
+				env:  map[string]string{"SHUTDOWN_TIMEOUT": "-5"},
+			},
+			want: config.Config{},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.Error(t, err)
+			},
+		},
+		{
+			name: "env invalid address",
+			args: args{
+				args: []string{"-a=localhost:9090"},
+				env:  map[string]string{"ADDRESS": "123:456:789"},
+			},
+			want: config.Config{},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.Error(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			got, err := parseArgs(fs, tt.args.args, envparser.NewParserWithOptions(env.Options{Environment: tt.args.env}))
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bq2cd/yp-go-metrics
 go 1.24.7
 
 require (
+	github.com/caarlos0/env/v11 v11.3.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/jarcoal/httpmock v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
+github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=

--- a/internal/app/envparser/envparser.go
+++ b/internal/app/envparser/envparser.go
@@ -1,0 +1,38 @@
+package envparser
+
+import (
+	"github.com/caarlos0/env/v11"
+)
+
+// Parser provides a thin wrapper over `github.com/caarlos0/env` package
+// to parse environment variables.
+type Parser interface {
+	// Parse accepts a pointer to a struct and populates any fields marked with `env` tags.
+	// Returns error if parsing of environment variables fails.
+	Parse(v any) error
+}
+
+type parser struct {
+	options *env.Options
+}
+
+// NewParser creates an instance of environment parser without custom options.
+func NewParser() *parser {
+	return &parser{options: nil}
+}
+
+// NewParserWithOptions creates an instance of environment parser with custom options.
+func NewParserWithOptions(opts env.Options) *parser {
+	return &parser{options: &opts}
+}
+
+// Parse calls corresponding function from github.com/caarlos0/env package
+// depending on the presence of custom options.
+// If no custom options are present, `env.Parse(v)` is called, otherwise
+// `env.ParseWithOptions(v, opts)` is called.
+func (p *parser) Parse(v any) error {
+	if p.options == nil {
+		return env.Parse(v)
+	}
+	return env.ParseWithOptions(v, *p.options)
+}

--- a/internal/app/envparser/envparser_test.go
+++ b/internal/app/envparser/envparser_test.go
@@ -1,0 +1,238 @@
+package envparser
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewParser(t *testing.T) {
+	tests := []struct {
+		name      string
+		assertion func(*testing.T, *parser)
+	}{
+		{
+			name: "options must be nil",
+			assertion: func(t *testing.T, got *parser) {
+				assert.Nil(t, got.options)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, NewParser())
+		})
+	}
+}
+
+func TestNewParserWithOptions(t *testing.T) {
+	type args struct {
+		opts env.Options
+	}
+	tests := []struct {
+		name      string
+		args      args
+		assertion func(*testing.T, *env.Options, *parser)
+	}{
+		{
+			name: "empty options",
+			args: args{opts: env.Options{}},
+			assertion: func(t *testing.T, want *env.Options, got *parser) {
+				assert.Equal(t, want, got.options)
+			},
+		},
+		{
+			name: "some options",
+			args: args{opts: env.Options{TagName: "custom"}},
+			assertion: func(t *testing.T, want *env.Options, got *parser) {
+				assert.Equal(t, want, got.options)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, &tt.args.opts, NewParserWithOptions(tt.args.opts))
+		})
+	}
+}
+
+func Test_parser_Parse(t *testing.T) {
+	type fields struct {
+		options *env.Options
+	}
+	type args struct {
+		setEnv func(*testing.T)
+		v      any
+	}
+	type want struct {
+		v any
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		want      want
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "default options",
+			fields: fields{
+				options: nil,
+			},
+			args: args{
+				setEnv: func(t *testing.T) {
+					t.Setenv("VAR1", "-15")
+					t.Setenv("VAR2", "31")
+					t.Setenv("VAR3", "dummy")
+				},
+				v: &struct {
+					VarInt    int    `env:"VAR1"`
+					VarUint   uint   `env:"VAR2"`
+					VarString string `env:"VAR3"`
+				}{},
+			},
+			want: want{
+				v: &struct {
+					VarInt    int    `env:"VAR1"`
+					VarUint   uint   `env:"VAR2"`
+					VarString string `env:"VAR3"`
+				}{
+					VarInt:    -15,
+					VarUint:   31,
+					VarString: "dummy",
+				},
+			},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "with custom environment",
+			fields: fields{
+				options: &env.Options{
+					Environment: map[string]string{"VAR1": "-12", "VAR2": "12", "VAR3": "a string"},
+				},
+			},
+			args: args{
+				setEnv: func(t *testing.T) {
+					t.Setenv("VAR1", "-15")
+					t.Setenv("VAR2", "31")
+					t.Setenv("VAR3", "dummy string")
+				},
+				v: &struct {
+					VarInt    int    `env:"VAR1"`
+					VarUint   uint   `env:"VAR2"`
+					VarString string `env:"VAR3"`
+				}{},
+			},
+			want: want{
+				v: &struct {
+					VarInt    int    `env:"VAR1"`
+					VarUint   uint   `env:"VAR2"`
+					VarString string `env:"VAR3"`
+				}{
+					VarInt:    -12,
+					VarUint:   12,
+					VarString: "a string",
+				},
+			},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "private fields are ignored",
+			fields: fields{
+				options: &env.Options{
+					Environment: map[string]string{"VAR1": "-12", "VAR2": "12"},
+				},
+			},
+			args: args{
+				setEnv: func(t *testing.T) {},
+				v: &struct {
+					Var1 int  `env:"VAR1"`
+					var2 uint `env:"VAR2"`
+				}{},
+			},
+			want: want{
+				v: &struct {
+					Var1 int  `env:"VAR1"`
+					var2 uint `env:"VAR2"`
+				}{
+					Var1: -12,
+					var2: 0,
+				},
+			},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "custom tag name",
+			fields: fields{
+				options: &env.Options{
+					TagName:     "custom",
+					Environment: map[string]string{"VAR1": "-12", "VAR2": "12"},
+				},
+			},
+			args: args{
+				setEnv: func(t *testing.T) {},
+				v: &struct {
+					Var1 int  `custom:"VAR1"`
+					Var2 uint `env:"VAR2"`
+				}{},
+			},
+			want: want{
+				v: &struct {
+					Var1 int  `custom:"VAR1"`
+					Var2 uint `env:"VAR2"`
+				}{
+					Var1: -12,
+					Var2: 0,
+				},
+			},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "custom envvar prefix",
+			fields: fields{
+				options: &env.Options{
+					Prefix:      "RRR_",
+					Environment: map[string]string{"RRR_VAR1": "-12", "RRR_VAR2": "12"},
+				},
+			},
+			args: args{
+				setEnv: func(t *testing.T) {},
+				v: &struct {
+					Var1 int  `env:"VAR1"`
+					Var2 uint `env:"VAR2"`
+				}{},
+			},
+			want: want{
+				v: &struct {
+					Var1 int  `env:"VAR1"`
+					Var2 uint `env:"VAR2"`
+				}{
+					Var1: -12,
+					Var2: 12,
+				},
+			},
+			assertion: func(t assert.TestingT, err error, v ...any) bool {
+				return assert.NoError(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &parser{
+				options: tt.fields.options,
+			}
+			tt.args.setEnv(t)
+			tt.assertion(t, p.Parse(tt.args.v))
+			assert.Equal(t, tt.want.v, tt.args.v)
+		})
+	}
+}


### PR DESCRIPTION
Allow configuration of the agent and server via environment variables.
When both environment variables and command-line flags are specified,
the variables take precedence.
